### PR TITLE
Add template scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ If an API is marked `(definition only)`, check the [crossplane-examples] repo
     Create Sets of subnets which logically belong together across *n* subnets
   - VpcNetwork (definition only) [***deprecated***] Use PeeredVpcNetwork instead
 
+### Adding a new API
+
+See the [`template`](./template) directory for details on how to add a new API
+
 ## Building API documentation
 
 This project uses crd-docs-generator to build the API spec

--- a/template/README.md
+++ b/template/README.md
@@ -1,0 +1,34 @@
+# API template
+
+This folder contains the template structure required for creating a new API
+
+Use the script `create.sh` to automatically create the skeleton structure used
+by this repository
+
+For example
+
+```bash
+./create.sh
+[INFO] Enter the group name > xrepository
+[INFO] Enter the composition name (lowercase, hyphenated) > github-pull-request
+[INFO] Enter the group class (camel-cased struct name) > PullRequest
+[INFO] creating directories
+[INFO] templating generate.go
+[INFO] templating main.go
+[INFO] templating doc.go
+[INFO] templating groupversion.go
+[INFO] Enter a shortname for the XRD type > pr
+[INFO] Enforce composition? (yes/no) > no
+Building...
+```
+
+- `group name` defines a group of compositions that logically belong together
+- `composition-name` is the name of the new composition to create
+- `group class` is the name of the struct for your composition.
+  This becomes the XRD structure. If it doesn't exist it will be created.
+  You can create multiple APIs in the same group, or you can share multiple
+  compositions behind a single API.
+
+  When creating a new API you will also be asked for
+  - `shortname` This is a shortname to give the CRD
+  - `enforced` If the composition being created should be enforced by the XRD

--- a/template/create.sh
+++ b/template/create.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+BASE_PATH="crossplane.giantswarm.io"
+
+RED=$(echo $'\033[31m');
+GREEN=$(echo $'\033[32m');
+YELLOW=$(echo $'\033[33m');
+BLUE=$(echo $'\033[34m');
+MAGENTA=$(echo $'\033[35m');
+CYAN=$(echo $'\033[36m');
+WHITE=$(echo $'\033[37m');
+
+RESET=$(echo $'\033[00m');
+
+BOLD=$(tput bold);
+NORMAL=$(tput sgr0)
+
+function inform()
+{
+    if [ "$1" = '-n' ] ; then
+        shift
+        echo -n "$WHITE[INFO]$RESET $@" 1>&2;
+    else
+        echo "$WHITE[INFO]$RESET $@" 1>&2;
+    fi
+}
+
+function question()
+{
+    local message="$@"
+    shift
+    inform -n "$message > "
+    read answer
+    if [ -z $answer ]; then
+        answer=$(question "$message")
+    fi
+    echo $answer
+}
+
+moduleroot ()
+{
+    local wd="$(pwd)";
+    while [ ! -d ".git" ] && [ "$(pwd)" != "/" ]; do
+        cd ..;
+    done;
+    local moduleName=$(basename `pwd`);
+    if [ "$moduleName" = "/" ]; then
+        error "Cannot find root directory for current module. Are you sure it's a git repository?" 1>&2;
+        cd "$wd";
+        return 1;
+    fi;
+    return 0
+}
+
+moduleroot || exit 1
+
+GROUP_NAME=$(question "Enter the group name" | tr '[:upper:]' '[:lower:]')
+COMPOSITION=$(question "Enter the composition name (lowercase, hyphenated)")
+GROUP_CLASS=$(question "Enter the group class (camel-cased struct name)")
+
+# Make sure at least the first letter is uppercase so go can export it
+GROUP_CLASS="${GROUP_CLASS^}"
+group_class_lower=$(tr '[:upper:]' '[:lower:]' <<< $GROUP_CLASS)
+
+inform "creating directories"
+mkdir -p ${BASE_PATH}/${GROUP_NAME}/{compositions/${COMPOSITION}/templates,v1alpha1,docs,examples}
+
+inform "templating generate.go"
+sed -e "s|<GROUP_NAME>|${GROUP_NAME}|g" \
+    template/files/generate.go.tpl > ${BASE_PATH}/${GROUP_NAME}/generate.go
+
+inform "templating main.go"
+
+sed -e "s|<GROUP_NAME>|${GROUP_NAME}|g" \
+    -e "s|<GROUP_CLASS>|${GROUP_CLASS}|g" \
+    -e "s|<COMPOSITION>|${COMPOSITION}|g" \
+     template/files/main.go.tpl > ${BASE_PATH}/${GROUP_NAME}/compositions/${COMPOSITION}/main.go
+
+if [ ! -f ${BASE_PATH}/${GROUP_NAME}/v1alpha1/doc.go ]; then
+    inform "templating doc.go"
+    sed -e "s|<GROUP_NAME>|${GROUP_NAME}|g" \
+        template/files/doc.go.tpl > ${BASE_PATH}/${GROUP_NAME}/v1alpha1/doc.go
+fi
+
+if [ ! -f ${BASE_PATH}/${GROUP_NAME}/v1alpha1/groupversion.go ]; then
+    inform "templating groupversion.go"
+    sed -e "s|<GROUP_NAME>|${GROUP_NAME}|g" -e "s|<GROUP_CLASS>|${GROUP_CLASS}|g" \
+        template/files/groupversion.go.tpl > ${BASE_PATH}/${GROUP_NAME}/v1alpha1/groupversion.go
+else
+    if ! grep -q "${GROUP_CLASS}List" ${BASE_PATH}/${GROUP_NAME}/v1alpha1/groupversion.go; then
+        inform "updating groupversion.go"
+        schema="SchemeBuilder.Register(\&${GROUP_CLASS}\{\}, \&${GROUP_CLASS}List\{\})"
+        sed -i "s|func init() {|func init() {\n\t$schema|" ${BASE_PATH}/${GROUP_NAME}/v1alpha1/groupversion.go
+    fi
+fi
+
+if [ ! -f "${BASE_PATH}/${GROUP_NAME}/v1alpha1/${group_class_lower}_types.go" ]; then
+    SHORTNAME=$(question "Enter a shortname for the XRD type" | tr '[:upper:]' '[:lower:]')
+    ENFORCE_COMPOSITION=$(question "Enforce composition? (yes/no)" | tr '[:upper:]' '[:lower:]')
+    sed -e "s|<GROUP_NAME>|${GROUP_NAME}|g" \
+        -e "s|<GROUP_CLASS>|${GROUP_CLASS}|g" \
+        -e "s|<SHORTNAME>|${SHORTNAME}|g" \
+        -e "s|<COMPOSITION>|${COMPOSITION}|g" \
+        template/files/xrd.go.tpl > ${BASE_PATH}/${GROUP_NAME}/v1alpha1/${group_class_lower}_types.go
+
+    if [ "$ENFORCE_COMPOSITION" = "no" ]; then
+        sed -i '/.*enforcedCompositionRef.*/d' ${BASE_PATH}/${GROUP_NAME}/v1alpha1/${group_class_lower}_types.go
+    fi
+fi
+
+make

--- a/template/files/doc.go.tpl
+++ b/template/files/doc.go.tpl
@@ -1,0 +1,5 @@
+// v1alpha1 contains API types that extend the Crossplane API.
+// +kubebuilder:object:generate=true
+// +groupName=<GROUP_NAME>.crossplane.giantswarm.io
+// +versionName=v1alpha1
+package v1alpha1

--- a/template/files/generate.go.tpl
+++ b/template/files/generate.go.tpl
@@ -1,0 +1,3 @@
+package apis
+
+//go:generate xrd-gen paths=./... xrd:allowDangerousTypes=true,crdVersions=v1 object:headerFile=../../hack/boilerplate.go.txt output:artifacts:config=../../apis/<GROUP_NAME>

--- a/template/files/groupversion.go.tpl
+++ b/template/files/groupversion.go.tpl
@@ -1,0 +1,27 @@
+package v1alpha1
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
+)
+
+// Package type metadata.
+const (
+	XRDGroup   = "<GROUP_NAME>.crossplane.giantswarm.io"
+	XRDVersion = "v1alpha1"
+)
+
+var (
+	// GroupVersion is the API Group Version used to register the objects
+	GroupVersion = schema.GroupVersion{Group: XRDGroup, Version: XRDVersion}
+
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+
+	// AddToScheme adds the types in this group-version to the given scheme.
+	AddToScheme = SchemeBuilder.AddToScheme
+)
+
+func init() {
+	SchemeBuilder.Register(&<GROUP_CLASS>{}, &<GROUP_CLASS>List{})
+}

--- a/template/files/main.go.tpl
+++ b/template/files/main.go.tpl
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"github.com/giantswarm/crossplane-gs-apis/crossplane.giantswarm.io/<GROUP_NAME>/v1alpha1"
+
+	xapiextv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+	"github.com/mproffitt/crossbuilder/pkg/generate/composition/build"
+)
+
+type builder struct{}
+
+var Builder = builder{}
+var TemplateBasePath string
+
+func (b *builder) GetCompositeTypeRef() build.ObjectKindReference {
+	return build.ObjectKindReference{
+		GroupVersionKind: v1alpha1.<GROUP_CLASS>GroupVersionKind,
+		Object:           &v1alpha1.<GROUP_CLASS>{},
+	}
+}
+
+func (b *builder) Build(c build.CompositionSkeleton) {
+	c.WithName("<COMPOSITION>").
+		WithMode(xapiextv1.CompositionModePipeline).
+		WithLabels(map[string]string{
+			// Add labels for uniquely identifying this composition
+		})
+
+	build.SetBasePath(TemplateBasePath)
+
+	// Add pipeline steps here
+
+	// Add the auto-ready function at the end
+	// This ensures the XR is marked ready when all
+	//   created MRs are ready
+	c.NewPipelineStep("function-auto-ready").
+		WithFunctionRef(xapiextv1.FunctionReference{
+			Name: "function-auto-ready",
+		})
+
+}

--- a/template/files/xrd.go.tpl
+++ b/template/files/xrd.go.tpl
@@ -1,0 +1,62 @@
+package v1alpha1
+
+import (
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// Repository type metadata.
+var (
+	<GROUP_CLASS>Kind      = "<GROUP_CLASS>"
+	<GROUP_CLASS>GroupKind = schema.GroupKind{
+		Group: XRDGroup,
+		Kind:  <GROUP_CLASS>Kind,
+	}.String()
+	<GROUP_CLASS>KindAPIVersion   = <GROUP_CLASS>Kind + "." + GroupVersion.String()
+	<GROUP_CLASS>GroupVersionKind = GroupVersion.WithKind(<GROUP_CLASS>Kind)
+)
+
+// +kubebuilder:object:root=true
+// +kubebuilder:storageversion
+// +genclient
+// +genclient:nonNamespaced
+//
+// +kubebuilder:resource:scope=Cluster,categories=crossplane
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:shortName=<SHORTNAME>
+// +crossbuilder:generate:xrd:claimNames:kind=<GROUP_CLASS>Claim,plural=<GROUP_CLASS>Claims
+// +crossbuilder:generate:xrd:defaultCompositionRef:name=<COMPOSITION>
+// +crossbuilder:generate:xrd:enforcedCompositionRef:name=<COMPOSITION>
+type <GROUP_CLASS> struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   <GROUP_CLASS>Spec   `json:"spec"`
+	Status <GROUP_CLASS>Status `json:"status,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+type <GROUP_CLASS>List struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+
+	Items []<GROUP_CLASS> `json:"items"`
+}
+
+// Use the `spec` struct to contain parameters you might not want to share
+// when nesting XRDs - these will usually be parameters that may be defined
+// in a parent.
+
+type <GROUP_CLASS>Spec struct {
+	xpv1.ResourceSpec `json:",inline"`
+
+	<GROUP_CLASS>Parameters `json:",inline"`
+}
+
+type <GROUP_CLASS>Parameters struct {
+}
+
+type <GROUP_CLASS>Status struct {
+	xpv1.ConditionedStatus `json:",inline"`
+}


### PR DESCRIPTION
This PR adds a new `template` script for quickly stubbing out a new API.

It will first create the necessary directories, then copy files into place, templating the placeholders as appropriate, then running `make` to autogenerate the XRD and Compositions