### PR TITLE
Use bash from environment instead of /bin/bash directly

### DIFF
--- a/template/create.sh
+++ b/template/create.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 BASE_PATH="crossplane.giantswarm.io"
 


### PR DESCRIPTION
On MAC /bin/bash is the system default bash that is still 3.x and the uppercase first ${VAR^} is bash 4.x+ only.