### PR TITLE
Fix plural name generation in template

### DIFF
--- a/template/create.sh
+++ b/template/create.sh
@@ -99,6 +99,7 @@ if [ ! -f "${BASE_PATH}/${GROUP_NAME}/v1alpha1/${group_class_lower}_types.go" ];
     ENFORCE_COMPOSITION=$(question "Enforce composition? (yes/no)" | tr '[:upper:]' '[:lower:]')
     sed -e "s|<GROUP_NAME>|${GROUP_NAME}|g" \
         -e "s|<GROUP_CLASS>|${GROUP_CLASS}|g" \
+        -e "s|<GROUP_CLASS_LOWER>|${GROUP_CLASS,,}|g" \
         -e "s|<SHORTNAME>|${SHORTNAME}|g" \
         -e "s|<COMPOSITION>|${COMPOSITION}|g" \
         template/files/xrd.go.tpl > ${BASE_PATH}/${GROUP_NAME}/v1alpha1/${group_class_lower}_types.go

--- a/template/files/xrd.go.tpl
+++ b/template/files/xrd.go.tpl
@@ -25,7 +25,7 @@ var (
 // +kubebuilder:resource:scope=Cluster,categories=crossplane
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=<SHORTNAME>
-// +crossbuilder:generate:xrd:claimNames:kind=<GROUP_CLASS>Claim,plural=<GROUP_CLASS>Claims
+// +crossbuilder:generate:xrd:claimNames:kind=<GROUP_CLASS>Claim,plural=<GROUP_CLASS_LOWER>claims
 // +crossbuilder:generate:xrd:defaultCompositionRef:name=<COMPOSITION>
 // +crossbuilder:generate:xrd:enforcedCompositionRef:name=<COMPOSITION>
 type <GROUP_CLASS> struct {


### PR DESCRIPTION
It must be lowercase RFC 1123 subdomain compliant.

```
The CompositeResourceDefinition "examples.xlaszlo.crossplane.giantswarm.io" is invalid:
* <generated_CRD_"exampleClaims.xlaszlo.crossplane.giantswarm.io">.metadata.name: Invalid value: "exampleClaims.xlaszlo.crossplane.giantswarm.io": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
* <generated_CRD_"exampleClaims.xlaszlo.crossplane.giantswarm.io">.spec.names.plural: Invalid value: "exampleClaims": a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')
```